### PR TITLE
#8 草の道ブロックなどの上で足元を掘った場合の修正

### DIFF
--- a/src/main/kotlin/blue/feelingso/khaos/KhaosConfig.kt
+++ b/src/main/kotlin/blue/feelingso/khaos/KhaosConfig.kt
@@ -3,6 +3,8 @@ package blue.feelingso.khaos
 import org.bukkit.configuration.file.FileConfiguration
 import java.lang.Math.abs
 import org.bukkit.Material
+import org.bukkit.block.Block
+import org.bukkit.inventory.ItemStack
 
 class KhaosConfig(bukkitConfig : FileConfiguration){
     private val bukkitConfig = bukkitConfig
@@ -31,4 +33,6 @@ class KhaosConfig(bukkitConfig : FileConfiguration){
     fun getAllowedItems(tool: Material): List<String> {
         return bukkitConfig.getStringList("allowTools.$tool")
     }
+
+    fun isTargetBlockByTool(tool: ItemStack, block: Block) = getAllowedItems(tool.type).contains(block.type.toString())
 }

--- a/src/main/kotlin/blue/feelingso/khaos/KhaosListener.kt
+++ b/src/main/kotlin/blue/feelingso/khaos/KhaosListener.kt
@@ -7,7 +7,6 @@ import org.bukkit.event.Listener
 import org.bukkit.event.block.Action
 import org.bukkit.event.block.BlockBreakEvent
 import org.bukkit.event.player.PlayerInteractEvent
-import kotlin.math.absoluteValue
 
 class KhaosListener(khaos :Khaos) : Listener {
     private val khaos = khaos
@@ -17,7 +16,6 @@ class KhaosListener(khaos :Khaos) : Listener {
     fun onBlockBroken(ev :BlockBreakEvent) {
         val conf = khaos.khaosConfig
         val player = ev.player
-        val block = ev.block
 
         // 破壊したブロックの数だけアイテムの耐久度を減らす（コード上は増やす）
         val tool = player.inventory.itemInMainHand

--- a/src/main/kotlin/blue/feelingso/khaos/Mogura.kt
+++ b/src/main/kotlin/blue/feelingso/khaos/Mogura.kt
@@ -1,6 +1,7 @@
 package blue.feelingso.khaos
 
 import org.bukkit.block.Block
+import org.bukkit.entity.Damageable
 import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
 import kotlin.math.absoluteValue
@@ -32,7 +33,9 @@ class Mogura(private val executor: Player, private val block: Block, private val
                         Compass.WEST
                     else Compass.EAST
 
-        // 最初に破壊したブロックと同じidのブロックを破壊．
+        // 対象になるブロックをここに格納する
+        val targetBlocks = mutableListOf<Block>()
+
         for (i in 1 - conf.radius until conf.radius) {
             for (j in 1 - conf.radius until conf.radius) {
                 for (k in conf.near until conf.far)
@@ -54,20 +57,16 @@ class Mogura(private val executor: Player, private val block: Block, private val
                             }
 
                     if (canDigBlock(targetBlock)) {
-                        targetBlock.breakNaturally(tool)
-                        if (conf.consume) tool.durability = (tool.durability + 1).toShort()
+                        targetBlocks.add(targetBlock)
                     }
                 }
             }
         }
 
-        // それでも1つ分は減らす
-        if (!conf.consume) tool.durability = (tool.durability + 1).toShort()
+        targetBlocks.forEach { it.breakNaturally(tool) }
 
-        // 上限に達したら壊す
-        if (tool.type.maxDurability < tool.durability) {
-            executor.inventory.remove(tool)
-        }
+        // 耐久を減らす
+        (tool.itemMeta as Damageable).damage(if (conf.consume) targetBlocks.size.toDouble() else 1.0)
     }
 
     // 対象のブロックが自分の足元より高い位置にあるか

--- a/src/main/kotlin/blue/feelingso/khaos/Mogura.kt
+++ b/src/main/kotlin/blue/feelingso/khaos/Mogura.kt
@@ -71,7 +71,7 @@ class Mogura(private val executor: Player, private val block: Block, private val
 
     // 対象のブロックが自分の足元より高い位置にあるか
     //　草の道やソウルサンドのような少し低いブロックの上で掘った際のことを考慮し、プレイヤの高さを切り上げている
-    private fun isHigherThanFloor(block: Block) = block.y > ceil(executor.location.y)
+    private fun isHigherThanFloor(block: Block) = block.y >= ceil(executor.location.y)
 
     private fun canDigBlock(block: Block): Boolean {
         // そのブロックはツールの対象に含まれているか

--- a/src/main/kotlin/blue/feelingso/khaos/Mogura.kt
+++ b/src/main/kotlin/blue/feelingso/khaos/Mogura.kt
@@ -53,7 +53,7 @@ class Mogura(private val executor: Player, private val block: Block, private val
                                 }
                             }
 
-                    if (canDigBlock(block)) {
+                    if (canDigBlock(targetBlock)) {
                         targetBlock.breakNaturally(tool)
                         if (conf.consume) tool.durability = (tool.durability + 1).toShort()
                     }

--- a/src/main/kotlin/blue/feelingso/khaos/Mogura.kt
+++ b/src/main/kotlin/blue/feelingso/khaos/Mogura.kt
@@ -1,0 +1,71 @@
+package blue.feelingso.khaos
+
+import org.bukkit.block.Block
+import org.bukkit.entity.Player
+import org.bukkit.inventory.ItemStack
+import kotlin.math.absoluteValue
+
+/**
+ * Digging blocks likes Mogura
+ *
+ */
+
+class Mogura(private val executor: Player, private val block: Block, private val tool: ItemStack, private val conf: KhaosConfig) {
+    private val blockTypes = conf.getAllowedItems(tool.type)
+    val runnable = blockTypes.contains(block.type.toString())
+
+    fun run() {
+        // 向いている向きとradius設定から破壊する範囲を設定し
+        val direction = executor.eyeLocation.direction.normalize()
+
+        // 方位を取得する
+        // x軸が東西，z軸が南北
+        val compass =
+                if (direction.z.absoluteValue > direction.x.absoluteValue)
+                    if (direction.z < 0)
+                        Compass.NORTH
+                    else
+                        Compass.SOUTH
+                else
+                    if (direction.x < 0)
+                        Compass.WEST
+                    else Compass.EAST
+
+        // 最初に破壊したブロックと同じidのブロックを破壊．
+        for (i in 1 - conf.radius until conf.radius) {
+            for (j in 1 - conf.radius until conf.radius) {
+                for (k in conf.near..(conf.far - 1))
+                {
+                    val targetBlock =
+                            when (compass) {
+                                Compass.EAST -> {
+                                    block.getRelative(k, i, j)
+                                }
+                                Compass.WEST -> {
+                                    block.getRelative(-k, i, j)
+                                }
+                                Compass.NORTH -> {
+                                    block.getRelative(j, i, -k)
+                                }
+                                Compass.SOUTH -> {
+                                    block.getRelative(j, i, k)
+                                }
+                            }
+
+                    if (blockTypes.contains(targetBlock.type.toString()) && (targetBlock.y >= executor.location.blockY || !conf.dontDigFloor)) {
+                        targetBlock.breakNaturally(tool)
+                        if (conf.consume) tool.durability = (tool.durability + 1).toShort()
+                    }
+                }
+            }
+        }
+
+        // それでも1つ分は減らす
+        if (!conf.consume) tool.durability = (tool.durability + 1).toShort()
+
+        // 上限に達したら壊す
+        if (tool.type.maxDurability < tool.durability) {
+            executor.inventory.remove(tool)
+        }
+    }
+}

--- a/src/main/kotlin/blue/feelingso/khaos/Mogura.kt
+++ b/src/main/kotlin/blue/feelingso/khaos/Mogura.kt
@@ -35,7 +35,7 @@ class Mogura(private val executor: Player, private val block: Block, private val
         // 最初に破壊したブロックと同じidのブロックを破壊．
         for (i in 1 - conf.radius until conf.radius) {
             for (j in 1 - conf.radius until conf.radius) {
-                for (k in conf.near..(conf.far - 1))
+                for (k in conf.near until conf.far)
                 {
                     val targetBlock =
                             when (compass) {

--- a/src/main/kotlin/blue/feelingso/khaos/Mogura.kt
+++ b/src/main/kotlin/blue/feelingso/khaos/Mogura.kt
@@ -4,6 +4,7 @@ import org.bukkit.block.Block
 import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
 import kotlin.math.absoluteValue
+import kotlin.math.ceil
 
 /**
  * Digging blocks likes Mogura
@@ -52,7 +53,7 @@ class Mogura(private val executor: Player, private val block: Block, private val
                                 }
                             }
 
-                    if (blockTypes.contains(targetBlock.type.toString()) && (targetBlock.y >= executor.location.blockY || !conf.dontDigFloor)) {
+                    if (canDigBlock(block)) {
                         targetBlock.breakNaturally(tool)
                         if (conf.consume) tool.durability = (tool.durability + 1).toShort()
                     }
@@ -67,5 +68,19 @@ class Mogura(private val executor: Player, private val block: Block, private val
         if (tool.type.maxDurability < tool.durability) {
             executor.inventory.remove(tool)
         }
+    }
+
+    // 対象のブロックが自分の足元より高い位置にあるか
+    //　草の道やソウルサンドのような少し低いブロックの上で掘った際のことを考慮し、プレイヤの高さを切り上げている
+    private fun isHigherThanFloor(block: Block) = block.y > ceil(executor.location.y)
+
+    private fun canDigBlock(block: Block): Boolean {
+        // そのブロックはツールの対象に含まれているか
+        if (!conf.isTargetBlockByTool(tool, block)) return false
+
+        if (!conf.dontDigFloor) return true
+
+        // 床下を掘らないという設定の場合、対象のブロックが自分の足元より高いか
+        return isHigherThanFloor(block)
     }
 }

--- a/src/main/kotlin/blue/feelingso/khaos/Mogura.kt
+++ b/src/main/kotlin/blue/feelingso/khaos/Mogura.kt
@@ -66,7 +66,9 @@ class Mogura(private val executor: Player, private val block: Block, private val
         targetBlocks.forEach { it.breakNaturally(tool) }
 
         // 耐久を減らす
-        (tool.itemMeta as Damageable).damage(if (conf.consume) targetBlocks.size.toDouble() else 1.0)
+        val damage = if (conf.consume) targetBlocks.size.toDouble() else 1.0
+        
+        tool.durability = (tool.durability + damage).toShort()
     }
 
     // 対象のブロックが自分の足元より高い位置にあるか

--- a/src/main/kotlin/blue/feelingso/khaos/Mogura.kt
+++ b/src/main/kotlin/blue/feelingso/khaos/Mogura.kt
@@ -67,8 +67,13 @@ class Mogura(private val executor: Player, private val block: Block, private val
 
         // 耐久を減らす
         val damage = if (conf.consume) targetBlocks.size.toDouble() else 1.0
-        
+
         tool.durability = (tool.durability + damage).toShort()
+
+        // 上限に達したら壊す
+        if (tool.type.maxDurability < tool.durability) {
+            executor.inventory.remove(tool)
+        }
     }
 
     // 対象のブロックが自分の足元より高い位置にあるか


### PR DESCRIPTION
close #8
草の道ブロックやソウルサンドなど若干低いブロックの上で足元を掘った場合の処理を修正した
プレイヤのy座標を切り上げて計算するわよ！