### PR TITLE
#17 耐久のエンチャントを考慮したダメージ計算に修正

### DIFF
--- a/src/main/kotlin/blue/feelingso/khaos/Mogura.kt
+++ b/src/main/kotlin/blue/feelingso/khaos/Mogura.kt
@@ -100,6 +100,6 @@ class Mogura(private val executor: Player, private val block: Block, private val
     private fun calculateDamage(item: ItemStack, count: Int): Int {
         val ratio = 1.0f / (item.getEnchantmentLevel(Enchantment.DURABILITY) + 1)
         if (ratio == 1.0f) return count
-        return (0 until count).filter { Math.random().toFloat() < ratio } .size
+        return (0 until count).filter { Math.random().toFloat() <= ratio } .size
     }
 }

--- a/src/main/kotlin/blue/feelingso/khaos/Mogura.kt
+++ b/src/main/kotlin/blue/feelingso/khaos/Mogura.kt
@@ -98,8 +98,12 @@ class Mogura(private val executor: Player, private val block: Block, private val
 
     // ItemStackと破壊個数からダメージを計算する
     private fun calculateDamage(item: ItemStack, count: Int): Int {
-        val ratio = 1.0f / (item.getEnchantmentLevel(Enchantment.DURABILITY) + 1)
-        if (ratio == 1.0f) return count
+        // 耐久エンチャントのレベル 無しの場合は0が返る
+        val enchantmentLevel = item.getEnchantmentLevel(Enchantment.DURABILITY)
+        // エンチャントが無い場合は確率の計算を回す必要がないのでそのまま個数を返却する
+        if (enchantmentLevel == 0) return count
+        val ratio = 1.0f / (enchantmentLevel + 1)
+        // count回計算して個数を返す
         return (0 until count).filter { Math.random().toFloat() <= ratio } .size
     }
 }

--- a/src/main/kotlin/blue/feelingso/khaos/Mogura.kt
+++ b/src/main/kotlin/blue/feelingso/khaos/Mogura.kt
@@ -68,7 +68,7 @@ class Mogura(private val executor: Player, private val block: Block, private val
         targetBlocks.forEach { it.breakNaturally(tool) }
 
         // 耐久を減らす
-        val damage = if (conf.consume) targetBlocks.size else 1
+        val damage = calculateDamage(tool, if (conf.consume) targetBlocks.size else 1)
 
         val damageable = tool.itemMeta as Damageable
 

--- a/src/main/kotlin/blue/feelingso/khaos/Mogura.kt
+++ b/src/main/kotlin/blue/feelingso/khaos/Mogura.kt
@@ -1,6 +1,7 @@
 package blue.feelingso.khaos
 
 import org.bukkit.block.Block
+import org.bukkit.enchantments.Enchantment
 import org.bukkit.inventory.meta.Damageable
 import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
@@ -93,5 +94,12 @@ class Mogura(private val executor: Player, private val block: Block, private val
 
         // 床下を掘らないという設定の場合、対象のブロックが自分の足元より高いか
         return isHigherThanFloor(block)
+    }
+
+    // ItemStackと破壊個数からダメージを計算する
+    private fun calculateDamage(item: ItemStack, count: Int): Int {
+        val ratio = 1.0f / (item.getEnchantmentLevel(Enchantment.DURABILITY) + 1)
+        if (ratio == 1.0f) return count
+        return (0 until count).filter { Math.random().toFloat() < ratio } .size
     }
 }


### PR DESCRIPTION
close #17 

`100 / (耐久エンチャのレベル) + 1`%の確率で耐久度が減るように
その計算を都度、破壊ブロックの個数分回している（エンチャなしの場合は無視してそのまま個数分を返す）
